### PR TITLE
as1-6809.c: range_5bit() had an incorrect range.

### DIFF
--- a/as1-6809.c
+++ b/as1-6809.c
@@ -454,7 +454,7 @@ unsigned can_shorten(ADDR *ap)
 
 unsigned range_5bit(ADDR *ap)
 {
-	if ((int16_t)ap->a_value >= -32 && (int16_t)ap->a_value <= 31)
+	if ((int16_t)ap->a_value >= -16 && (int16_t)ap->a_value <= 15)
 		return 1;
 	return 0;
 }


### PR DESCRIPTION
I think it should be -16 .. +15, not -32 .. +31.

I was seeing LEAS -16,S in the emulator when I was expecting to see LEAS 16,S.
And page 150 of https://colorcomputerarchive.com/repo/Documents/Books/Motorola%206809%20and%20Hitachi%206309%20Programming%20Reference%20(Darren%20Atkinson).pdf
says "5 bit offset (-16 to +15 )".