### PR TITLE
tms9900: fix binary of MPYS and DIVS

### DIFF
--- a/as6-tms9900.c
+++ b/as6-tms9900.c
@@ -94,8 +94,8 @@ SYM	sym[] = {
 
         /* 10 bits of opcode and a mode/reg pair */
         /* TMS9900/9995 TMS990/12 and later only */
-        {	0,	"mpys",		TSMD,		0x08C0	},
-        {	0,	"divs",		TSMD,		0x0880	},
+        {	0,	"mpys",		TSMD,		0x01C0	},
+        {	0,	"divs",		TSMD,		0x0180	},
         
         /* 4.5.4 XOP */
         


### PR DESCRIPTION
The binaries generated by TMS9995's MPYS and DIVS are SRA's.
This PR will fix them correctly.